### PR TITLE
Fastled Helper: Concatenate nested namespaces

### DIFF
--- a/components/fastled_helper/fastled_helper.cpp
+++ b/components/fastled_helper/fastled_helper.cpp
@@ -1,7 +1,6 @@
 #include "esphome.h"
 
-namespace esphome {
-namespace fastled_helper {
+namespace esphome::fastled_helper {
 
 void FastledHelper::setup() {}  // setup()
 
@@ -32,5 +31,4 @@ void FastledHelper::dump_config() {
 #endif
 }  // dump_config()
 
-}  // namespace fastled_helper
-}  // namespace esphome
+}  // namespace esphome::fastled_helper

--- a/components/fastled_helper/fastled_helper.h
+++ b/components/fastled_helper/fastled_helper.h
@@ -1,7 +1,6 @@
 #pragma once
 
-namespace esphome {
-namespace fastled_helper {
+namespace esphome::fastled_helper {
 
 static const char *const FASTLED_HELPER_VERSION = "2025.10.1";
 static const char *const TAG = "fastled_helper";
@@ -16,5 +15,4 @@ class FastledHelper : public Component {
 #endif
 };  // FastledHelper
 
-}  // namespace fastled_helper
-}  // namespace esphome
+}  // namespace esphome::fastled_helper

--- a/components/fastled_helper/palettes.h
+++ b/components/fastled_helper/palettes.h
@@ -6,8 +6,7 @@
 
 #include <FastLED.h>
 
-namespace esphome {
-namespace fastled_helper {
+namespace esphome::fastled_helper {
 
 #undef DEFINE_GRADIENT_PALETTE
 
@@ -406,7 +405,6 @@ static CRGBPalette16 paletteArr[] = {
     bhw1_28_gp,
 };
 
-}  // namespace fastled_helper
-}  // namespace esphome
+}  // namespace esphome::fastled_helper
 
 #endif

--- a/components/fastled_helper/utils.h
+++ b/components/fastled_helper/utils.h
@@ -6,8 +6,7 @@
 #include "palettes.h"
 #include "esphome/core/color.h"
 
-namespace esphome {
-namespace fastled_helper {
+namespace esphome::fastled_helper {
 
 #define ARRAY_SIZE(array) ((sizeof(array)) / (sizeof(array[0])))
 
@@ -430,5 +429,4 @@ static CRGB getCRGBForBand(int x, int pal) {
 
 #endif  // PALETTES
 
-}  // namespace fastled_helper
-}  // namespace esphome
+}  // namespace esphome::fastled_helper


### PR DESCRIPTION
Conversion of `namespace foo { namespace bar { ... } }` to `namespace foo::bar { ... }` (C++17 nested namespace concatenation). **No semantic changes.**