### PR TITLE
Music Leds: Concatenate nested namespaces

### DIFF
--- a/components/music_leds/audio_source.h
+++ b/components/music_leds/audio_source.h
@@ -4,13 +4,11 @@
 
 #include "esphome/components/i2s_audio/microphone/i2s_audio_microphone.h"
 
-namespace esphome {
-namespace music_leds {
+namespace esphome::music_leds {
 
 class AudioSource : public i2s_audio::I2SAudioMicrophone {
  public:
   using i2s_audio::I2SAudioMicrophone::read_;
 };
 
-}  // namespace music_leds
-}  // namespace esphome
+}  // namespace esphome::music_leds

--- a/components/music_leds/music_leds.cpp
+++ b/components/music_leds/music_leds.cpp
@@ -25,8 +25,7 @@
 #define NUM_GEQ_CHANNELS 16  // number of frequency channels. Don't change !!
 #define SAMPLES_FFT 512      // Samples in an FFT batch - This value MUST ALWAYS be a power of 2
 
-namespace esphome {
-namespace music_leds {
+namespace esphome::music_leds {
 
 static const uint32_t BUFFER_SIZE = sizeof(I2S_datatype) * SAMPLES_FFT;
 
@@ -1671,5 +1670,4 @@ void MusicLedsSoundLoopTrigger::process(float volume_smth, int16_t volume_raw, f
 }
 #endif
 
-}  // namespace music_leds
-}  // namespace esphome
+}  // namespace esphome::music_leds

--- a/components/music_leds/music_leds.h
+++ b/components/music_leds/music_leds.h
@@ -16,8 +16,7 @@
 
 #include <FastLED.h>
 
-namespace esphome {
-namespace music_leds {
+namespace esphome::music_leds {
 
 static const char *const TAG = "music_leds";
 static const char *const MUSIC_LEDS_VERSION = "2025.7.1";
@@ -212,5 +211,4 @@ class MusicLedsSoundLoopTrigger : public Trigger<float, int16_t, float, bool> {
 };  // class MusicLedsSoundLoopTrigger
 #endif
 
-}  // namespace music_leds
-}  // namespace esphome
+}  // namespace esphome::music_leds

--- a/components/music_leds/music_leds_effect.cpp
+++ b/components/music_leds/music_leds_effect.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace music_leds {
+namespace esphome::music_leds {
 
 MusicLedsLightEffect::MusicLedsLightEffect(const char *name) : AddressableLightEffect(name) {}
 
@@ -26,5 +25,4 @@ void MusicLedsLightEffect::apply(light::AddressableLight &it, const Color &curre
   }
 }
 
-}  // namespace music_leds
-}  // namespace esphome
+}  // namespace esphome::music_leds

--- a/components/music_leds/music_leds_effect.h
+++ b/components/music_leds/music_leds_effect.h
@@ -2,8 +2,7 @@
 
 #include "esphome/components/light/addressable_light_effect.h"
 
-namespace esphome {
-namespace music_leds {
+namespace esphome::music_leds {
 
 class MusicLeds;
 
@@ -22,5 +21,4 @@ class MusicLedsLightEffect : public light::AddressableLightEffect {
   MusicLeds *music_leds_{nullptr};
 };
 
-}  // namespace music_leds
-}  // namespace esphome
+}  // namespace esphome:music_leds

--- a/components/music_leds/music_leds_effect.h
+++ b/components/music_leds/music_leds_effect.h
@@ -21,4 +21,4 @@ class MusicLedsLightEffect : public light::AddressableLightEffect {
   MusicLeds *music_leds_{nullptr};
 };
 
-}  // namespace esphome:music_leds
+}  // namespace esphome::music_leds


### PR DESCRIPTION
Conversion of `namespace foo { namespace bar { ... } }` to `namespace foo::bar { ... }` (C++17 nested namespace concatenation). **No semantic changes.**